### PR TITLE
Switch currencies from AUD to USD

### DIFF
--- a/internal/users/user.go
+++ b/internal/users/user.go
@@ -108,7 +108,12 @@ func (u *User) EnabledInstallations() ([]int, error) {
 }
 
 func (u *User) ProcessStripePayment(token, plan string) error {
-	if u.StripeCustomerID != "" {
+	// 2017-01-22, we've switched from AUD to USD currency in stripe, so existing
+	// customers need a new stripe customer ID as stripe won't accept a single
+	// customer with multiple currencies. So create a new stripe customer for
+	// these users. We can remove the "u.UserID > 17"  condition once everyone is
+	// off of the PersonalMonthly plan. See commit message for more information.
+	if u.StripeCustomerID != "" && u.UserID > 17 {
 		// TODO this should upgrade the existing plan (prorata) #8
 		_, err := sub.New(&stripe.SubParams{
 			Customer: u.StripeCustomerID,

--- a/templates/console-billing.tmpl
+++ b/templates/console-billing.tmpl
@@ -52,9 +52,9 @@
         <tbody>
             <tr>
                 <th>Price</th>
-                <td>$AUD 4.99/Month</td>
-                <td>$AUD 9.99/Month</td>
-                <td>$AUD 34.99/Month</td>
+                <td>$USD 3.99/Month</td>
+                <td>$USD 7.99/Month</td>
+                <td>$USD 29.99/Month</td>
             </tr>
             <tr>
                 <th>Organisations</th>
@@ -63,7 +63,7 @@
                 <td>Unlimited</td>
             </tr>
             <tr>
-                <th>Requests per day</th>
+                <th>Builds per day</th>
                 <td>10</td>
                 <td>50</td>
                 <td>200</td>
@@ -79,10 +79,10 @@
             <tr>
                 <th></th>
                 <td>
-                    <form class="event-stripe" action="/console/billing/process/PersonalMonthly" method="POST">
+                    <form class="event-stripe" action="/console/billing/process/PersonalMonthlyUSD" method="POST">
                         <script
                             src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-                            data-amount="499"
+                            data-amount="399"
                             data-description="Personal Monthly"
                             data-name="gopherci.io"
                             data-key="{{ .StripePublishKey }}"
@@ -92,12 +92,12 @@
                             data-panel-label="Subscribe"
                             data-label="Subscribe"
                             data-email="{{ .Email }}"
-                            data-currency="aud">
+                            data-currency="usd">
                         </script>
                     </form>
                 </td>
                 <td>
-                    <form class="event-stripe" action="/console/billing/process/ProfessionalMonthly" method="POST">
+                    <form class="event-stripe" action="/console/billing/process/ProfessionalMonthlyUSD" method="POST">
                         <script
                             src="https://checkout.stripe.com/checkout.js" class="stripe-button"
                             data-amount="799"
@@ -110,15 +110,15 @@
                             data-panel-label="Subscribe"
                             data-label="Subscribe"
                             data-email="{{ .Email }}"
-                            data-currency="aud">
+                            data-currency="usd">
                         </script>
                     </form>
                 </td>
                 <td>
-                    <form class="event-stripe" action="/console/billing/process/SignificantMonthly" method="POST">
+                    <form class="event-stripe" action="/console/billing/process/SignificantMonthlyUSD" method="POST">
                         <script
                             src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-                            data-amount="2499"
+                            data-amount="2999"
                             data-description="Significant Contributor Monthly"
                             data-name="gopherci.io"
                             data-key="{{ .StripePublishKey }}"
@@ -128,7 +128,7 @@
                             data-panel-label="Subscribe"
                             data-label="Subscribe"
                             data-email="{{ .Email }}"
-                            data-currency="aud">
+                            data-currency="usd">
                         </script>
                     </form>
                 </td>

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -224,9 +224,8 @@
       <div class="column is-4">
         <nav class="panel">
           <div class="panel-heading plan-price">
-            <small>$AUD</small> 4.99<small>/month</small>
+            <small>$USD</small> 3.99<small>/month</small>
           </div>
-          <div class="panel-block plan-usd">Approximately $4.00 USD</div>
           <div class="panel-block plan-name">Personal</div>
           <div class="panel-block plan-details"><b>Unlimited</b> Public Repos</div>
           <div class="panel-block"><b>Unlimited</b> Private Repos</div>
@@ -238,9 +237,8 @@
       <div class="column is-4">
         <nav class="panel">
           <div class="panel-heading plan-price">
-            <small>$AUD</small> 9.99<small>/month</small>
+            <small>$USD</small> 7.99<small>/month</small>
           </div>
-          <div class="panel-block plan-usd">Approximately $8.00 USD</div>
           <div class="panel-block plan-name">Professional</div>
           <div class="panel-block plan-details"><b>Unlimited</b> Public Repos</div>
           <div class="panel-block"><b>Unlimited</b> Private Repos</div>
@@ -252,9 +250,8 @@
       <div class="column is-4">
         <nav class="panel">
           <div class="panel-heading plan-price">
-            <small>$AUD</small> 34.99<small>/month</small>
+            <small>$USD</small> 29.99<small>/month</small>
           </div>
-          <div class="panel-block plan-usd">Approximately $27.00 USD</div>
           <div class="panel-block plan-name">Significant Contributor</div>
           <div class="panel-block plan-details"><b>Unlimited</b> Public Repos</div>
           <div class="panel-block"><b>Unlimited</b> Private Repos</div>


### PR DESCRIPTION
I hadn't initially realised I could charge people in USD whilst linking
to an Australia bank account. I'd prefer to bill in USD as most of the
running costs for GopherCI is in USD anyway.

There's an edge case though, where existing customers need to be
allocated a new Stripe customer ID, as Stripe won't allow an existing
customer to have subscriptions (even though one is disabled) in
different currencies.

So, for those customers, we'll just create a new Stripe customer for
them when they change plans, and eventually, when everyone is off of
the old PersonalMonthly plan (and onto PersonalMonthlyUSD or similar)
we can just delete those plans. The only side effect is those customers
won't be able to see their existing, cancelled, subscriptions, but
we won't delete the customer in Stripe.