### PR TITLE
Request less GitHub scopes during OAuth login

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -194,16 +194,16 @@ func consoleIndexHandler(w http.ResponseWriter, r *http.Request) {
 
 	ghUser, _, err := user.GHClient.Users.Get("")
 	if err != nil {
-		logger.WithError(err).Error("could not get gh user")
-		errorHandler(w, r, http.StatusInternalServerError, "")
+		logger.WithError(err).Info("could not get github user, reattempting oauth flow")
+		http.Redirect(w, r, "/gh/login", http.StatusFound)
 		return
 	}
 
 	// Get list of organisations from github api for this user
 	ghMemberships, _, err := user.GHClient.Organizations.ListOrgMemberships(&github.ListOrgMembershipsOptions{State: "active"})
 	if err != nil {
-		logger.WithError(err).Error("could not get gh list org memberships")
-		errorHandler(w, r, http.StatusInternalServerError, "")
+		logger.WithError(err).Info("could not get github list org memberships, reattempting oauth flow")
+		http.Redirect(w, r, "/gh/login", http.StatusFound)
 		return
 	}
 

--- a/internal/users/github_test.go
+++ b/internal/users/github_test.go
@@ -34,7 +34,7 @@ func TestOAuthLoginHandler(t *testing.T) {
 	um.OAuthLoginHandler(w, r)
 
 	// Expect a redirect (this is not a great test)
-	want := "http://example.com?access_type=online&client_id=id&response_type=code&scope=user+read%3Aorg&state="
+	want := "http://example.com?access_type=online&client_id=id&response_type=code&scope=user%3Aemail+read%3Aorg&state="
 	if !strings.HasPrefix(w.Result().Header.Get("Location"), want) {
 		t.Errorf("Location header does not have expected prefix\nhave: %v\nwant: %v", w.Result().Header.Get("Location"), want)
 	}

--- a/internal/users/user-manager.go
+++ b/internal/users/user-manager.go
@@ -29,7 +29,7 @@ func NewUserManager(logger *logrus.Entry, db *sqlx.DB, clientID, clientSecret, s
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
 			Endpoint:     ghoauth.Endpoint,
-			Scopes:       []string{"user", "read:org"},
+			Scopes:       []string{"user:email", "read:org"},
 		},
 	}
 }

--- a/migrations/6_clear_github_tokens.sql
+++ b/migrations/6_clear_github_tokens.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+UPDATE users SET github_token = NULL
+
+-- +migrate Down
+


### PR DESCRIPTION
Previously we've been asking for access to the user scope, but I
don't believe I need it at all after some further testing, it's
just the user's email.

I will still need read only access to organisations, in order to
list all organisations so the user can enable an installation. But
there may be a workflow that could enable us to remove this scope
too.

Before:

![screen shot 2017-02-01 at 8 22 37 am](https://cloud.githubusercontent.com/assets/1834577/22486019/b8863bd0-e857-11e6-8525-22f3cea07a89.png)

After:

![screen shot 2017-02-01 at 8 22 55 am](https://cloud.githubusercontent.com/assets/1834577/22486031/c24e65ca-e857-11e6-9022-73f2e1aaf2ee.png)

I can't recall why we required so many permissions, I'll test further, but I believe this is reasonable.